### PR TITLE
add conditional check for $ZDOTDIR when using zsh.

### DIFF
--- a/compile/install.sh
+++ b/compile/install.sh
@@ -23,7 +23,7 @@ case "`uname`" in
     ;;
 esac
 
-if [ "$?" != "0" ] 
+if [ "$?" != "0" ]
 then
   exit 1
 fi
@@ -35,7 +35,12 @@ write_profile()
 }
 
 if   [[ "$SHELL" = */zsh ]]; then
-    write_profile ~/.zshrc
+    source ~/.zshenv
+    if [ -d "$ZDOTDIR" ]; then
+        write_profile "$ZDOTDIR"/.zshrc
+    else
+        write_profile ~/.zshrc
+    fi
 elif [[ "$SHELL" = */ksh ]]; then
     write_profile ~/.kshrc
 elif [[ "$SHELL" = */bash ]]; then
@@ -43,5 +48,5 @@ elif [[ "$SHELL" = */bash ]]; then
     if [ "$(uname)" == "Darwin" ]; then
         write_profile ~/.bash_profile
     fi
-else write_profile ~/.profile 
+else write_profile ~/.profile
 fi


### PR DESCRIPTION
Hello, I hope this is welcome!

Whenever I build this, I end up with a new `~/.zshrc` because I keep mine in `$ZDOTDIR/.zshrc`. So, I figured adding an additional check was simple enough. I was hoping to avoid sourcing `.zshenv` but did not find a way.

Thank you for your work, and let me know what you think! 