### PR TITLE
use pthread instead of lpthread

### DIFF
--- a/compile/ninja/linux.ninja
+++ b/compile/ninja/linux.ninja
@@ -116,7 +116,7 @@ build $obj/source_bootstrap/main.obj: cxx_source_bootstrap $
 build $obj/source_bootstrap/progdir.obj: cxx_source_bootstrap $
     3rd/bee.lua/bootstrap/progdir.cpp
 rule link_luamake
-  command = $cc $in -o $out -lm -ldl -lpthread -Wl,-E -lpthread $
+  command = $cc $in -o $out -lm -ldl -pthread -Wl,-E -pthread $
     -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -static-libgcc -s
   description = Link    Exe $out
 build $bin/luamake: link_luamake $obj/source_bootstrap/main.obj $


### PR DESCRIPTION
`-lpthread` is only linking with the thread library, while `-pthread` actually means enabling thread support, which includes in the case of riscv64 `-latomic`, but also correctly define some macros when compiling code.