### PR TITLE
Improve compile.sh (MacOS ZSH fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # luamake
 
-## Install
+## Install Instructions
+
+### 1. Clone repo and submodules
 
 ```bash
 git clone https://github.com/actboy168/luamake
@@ -8,15 +10,20 @@ cd luamake
 git submodule update --init
 ```
 
-- Windows (msvc)
+### 2. Install Ninja
+
+See: [Ninja Build System Pre Build Packages]((https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages))
+
+### 3. Run install script:
+
+#### Windows (msvc):
 ```
 compile/install.bat
 ```
 
-- Windows (mingw) / MacOS / Linux / Android / NetBSD / FreeBSD / OpenBSD
+#### Linux / MacOS / Android / NetBSD / FreeBSD / OpenBSD / Windows (mingw)
 
 ```
-Install ninja
 compile/install.sh
 ```
 


### PR DESCRIPTION
compile.sh behaves very badly on MacOS. It uses the wrong 'echo' and appended the following into my `~/.zshrc/`:

```
-e
alias luamake="/Users/peter/source/lua-language-server/3rd/luamake/luamake"
```

The `-e` throws an error on every subsequent shell launch. :(

----

Changes in this PR:
* install.sh: Replace echo with printf (fixes above zshrc error)
* install.sh: remove bashisms (`==`, `source`) as this is a /bin/sh script.
* install.sh: Support paths with spaces
* build.sh: Support paths with spaces
* Improved install instructions in README.md