### PR TITLE
Fix dynamic library linking when using clang in Linux.

### DIFF
--- a/scripts/compiler/clang.lua
+++ b/scripts/compiler/clang.lua
@@ -138,8 +138,13 @@ function clang.rule_dll(w, name, ldflags)
                 rspfile = "$out.rsp",
                 rspfile_content = "$in",
             })
-    else
+    elseif globals.os == "macos" or globals.os == "ios" then
         w:rule("link_"..name, ([[$cc -dynamiclib -Wl,-undefined,dynamic_lookup $in -o $out %s]]):format(ldflags),
+            {
+                description = "Link    Dll $out"
+            })
+    else
+        w:rule("link_"..name, ([[$cc --shared -Wl,-undefined,dynamic_lookup $in -o $out %s]]):format(ldflags),
             {
                 description = "Link    Dll $out"
             })

--- a/scripts/compiler/emcc.lua
+++ b/scripts/compiler/emcc.lua
@@ -31,6 +31,7 @@ function emcc.update_ldflags(ldflags, attribute)
     else
         ldflags[#ldflags+1] = "-g0"
     end
+    ldflags[#ldflags+1] = emcc.optimize[attribute.optimize]
 end
 
 function emcc.rule_dll(w, name, ldflags)


### PR DESCRIPTION
## Error in Linux

```
clang: warning: argument unused during compilation: '-dynamiclib' [-Wunused-command-line-argument]
ld.lld: error: undefined symbol: main
```

The `-shared` option is required in Linux.

## Optimization when linking

<https://emscripten.org/docs/tools_reference/emcc.html>