### PR TITLE
add macos arch variable support

### DIFF
--- a/scripts/globals.lua
+++ b/scripts/globals.lua
@@ -44,6 +44,8 @@ globals.arch = globals.arch or (function ()
         else
             return "x86"
         end
+    elseif globals.os == "macos" then
+      return require "bee.platform".Arch
     end
 end)()
 globals.builddir = globals.builddir or "build"


### PR DESCRIPTION
lm.arch currently has a value only in the Window. Now, expose the arch variable from Bee on the macOS.

