### PR TITLE
Fix building in paths that contain spaces

### DIFF
--- a/compile/build.sh
+++ b/compile/build.sh
@@ -33,4 +33,4 @@ case "`uname`" in
 esac
 
 DIR=$(cd `dirname $0`/..; pwd)
-exec ninja -f $DIR/compile/ninja/$OS.ninja $*
+exec ninja -f "$DIR/compile/ninja/$OS.ninja" $*

--- a/compile/install.sh
+++ b/compile/install.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env sh
 
+DIR="$(cd "$(dirname "$0")"/.. || exit 1; pwd)"
+
+cd "$DIR" || exit 1
+
 if ! sh ./compile/build.sh $*
 then
   exit 1
 fi
 
-DIR="$(cd "$(dirname "$0")"/.. || exit 1; pwd)"
 
 write_alias() {
   if grep -sq "luamake" "$1"
   then
     echo "luamake alias already defined in $1"
   else
-    printf '\nalias luamake="%s"\n' "$DIR/luamake" >> "$1"
+    printf '\nalias luamake="%s"\n' "'$DIR/luamake'" >> "$1"
     echo "luamake alias added to $1. (You may need to restart your shell.)"
   fi
 }


### PR DESCRIPTION
Tested on my Mac

1. You can now start the `compile/install.sh` script from anywhere, as the cd line is now above the `compile/build.sh` line
2. The `compile/build.sh` script has quotes around the `$DIR` path so that it will still work with spaces
3. The `compile/install.sh` script puts quotes around the path that gets added to your `.zshrc` or `.bashrc` or similar so that it will still work if you have a space in your path.