### PR TITLE
fix: ArchAlias in `scripts/env/msvc.lua`

### DIFF
--- a/scripts/env/msvc.lua
+++ b/scripts/env/msvc.lua
@@ -285,6 +285,7 @@ local msvc_deps_prefix
 local ArchAlias = {
     x86_64 = "x64",
     x86 = "x86",
+    arm64 = "arm64",
 }
 
 local function getConsoleCP()


### PR DESCRIPTION
PS: I've been waiting for LuaLS on Windows ARM64 for quite a while 😭. Thanks for your work; it's so close—just a few fixes away.