### PR TITLE
fix: path.__div 运算符应返回路径对象而非普通字符串

### DIFF
--- a/scripts/pathutil.lua
+++ b/scripts/pathutil.lua
@@ -14,9 +14,11 @@ local function is(path)
     return type(path) == "userdata" or (type(path) == "table" and path.__path)
 end
 
-local path_mt = {
+local path_mt
+path_mt = {
     __div = function(a, b)
-        return fsutil.join(tostring(a), tostring(b))
+        local p = fsutil.join(tostring(a), tostring(b))
+        return setmetatable({ __path = p }, path_mt)
     end,
     __tostring = function(self)
         return self.__path


### PR DESCRIPTION
## 问题描述

在使用 `lm:path()` 创建路径对象后，通过 `/` 运算符（`__div`）拼接子路径时，得到的结果是一个**普通字符串**，而非路径对象。

### 触发路径

`3rd/bee.lua/compile/common.lua` 中有如下代码：

`lua
lm.luadir = lm:path("3rd/lua"..lm.lua)
lm:source_set "source_lua" {
    sources = {
        lm.luadir / "onelua.c",  -- __div 运算符
    },
}
`

`lm.luadir / "onelua.c"` 调用 `__div`，返回的是 `fsutil.join(...)` 的结果——一个普通字符串，例如 `"3rd/bee.lua/3rd/lua55/onelua.c"`。

### 为什么会产生重复路径

该字符串被传入 `source_set` 的 `sources` 字段，最终由 `glob.lua` 的 `pattern_preprocess` 函数处理：

`lua
local ispath, path = pathutil.tovalue(pattern)
if not ispath then
    path = fsutil.absolute(root, path)  -- 再次拼接 rootdir
end
`

`pathutil.tovalue` 通过 `pathutil.is()` 判断是否已是路径对象。由于 `__div` 返回的是普通字符串（`is()` 返回 false），`rootdir`（此时为 `3rd/bee.lua`）被再拼一遍，生成：

`
3rd/bee.lua/3rd/bee.lua/3rd/lua55/onelua.c
`

最终 ninja 报告文件缺失，编译失败：

`
ninja: error: '3rd/bee.lua/3rd/bee.lua/3rd/lua55/onelua.c',
       needed by 'build/obj/source_lua/onelua.obj',
       missing and no known rule to make it
`

## 修复方式

将 `path_mt` 的声明与初始化分离，使 `__div` 闭包能引用 `path_mt` 自身，从而让拼接结果继续用 `setmetatable` 包装为路径对象：

`lua
-- 修复前
local path_mt = {
    __div = function(a, b)
        return fsutil.join(tostring(a), tostring(b))  -- 返回普通字符串
    end,
}

-- 修复后
local path_mt
path_mt = {
    __div = function(a, b)
        local p = fsutil.join(tostring(a), tostring(b))
        return setmetatable({ __path = p }, path_mt)  -- 返回路径对象
    end,
}
`

修复后 `pathutil.is()` 能正确识别该值，`glob` 不会再重复追加 `rootdir`，路径恢复正常。